### PR TITLE
Removed subnet shim for DB

### DIFF
--- a/.github/workflows/tflint.yaml
+++ b/.github/workflows/tflint.yaml
@@ -1,8 +1,8 @@
 name: Lint
 on:
-  push:
-    branches: [ master ]
   pull_request:
+    branches:
+      - main
 
 jobs:
   tflint:

--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ No modules.
 | <a name="input_truefoundry_db_override_name"></a> [truefoundry\_db\_override\_name](#input\_truefoundry\_db\_override\_name) | Truefoundry db name override | `string` | n/a | yes |
 | <a name="input_truefoundry_db_private_dns_zone_id"></a> [truefoundry\_db\_private\_dns\_zone\_id](#input\_truefoundry\_db\_private\_dns\_zone\_id) | Private DNS zone ID | `string` | n/a | yes |
 | <a name="input_truefoundry_db_subnet_cidr"></a> [truefoundry\_db\_subnet\_cidr](#input\_truefoundry\_db\_subnet\_cidr) | CIDR of the subnet which we should use for the db | `string` | n/a | yes |
-| <a name="input_truefoundry_db_subnet_id"></a> [truefoundry\_db\_subnet\_id](#input\_truefoundry\_db\_subnet\_id) | Subnet ID where truefoundry database is hosted | `string` | `""` | no |
-| <a name="input_truefoundry_db_subnet_shim"></a> [truefoundry\_db\_subnet\_shim](#input\_truefoundry\_db\_subnet\_shim) | DB subnet shim | `bool` | n/a | yes |
 | <a name="input_truefoundry_db_vnet_name"></a> [truefoundry\_db\_vnet\_name](#input\_truefoundry\_db\_vnet\_name) | Name of the virtual network | `string` | n/a | yes |
 | <a name="input_unique_name"></a> [unique\_name](#input\_unique\_name) | Truefoundry deployment unique name | `string` | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@ Truefoundry Azure Control Plane Module
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.69.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.5.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.69.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
 
@@ -21,24 +25,24 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_container_registry.svcfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry) | resource |
-| [azurerm_federated_identity_credential.mlfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
-| [azurerm_federated_identity_credential.svcfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
-| [azurerm_key_vault.akv_svcfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault) | resource |
-| [azurerm_postgresql_flexible_server.postgresql_flexible](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server) | resource |
-| [azurerm_postgresql_flexible_server_configuration.postgres_flexible_configuration](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
-| [azurerm_postgresql_flexible_server_database.postgresql_flexible_database](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_database) | resource |
-| [azurerm_postgresql_flexible_server_firewall_rule.postgres_flexible_firewall_rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_firewall_rule) | resource |
-| [azurerm_role_assignment.acr_svcfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.mlfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.storage_svcfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_storage_account.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
-| [azurerm_storage_container.truefoundry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
-| [azurerm_subnet.postgresql_flexible_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
-| [azurerm_user_assigned_identity.mlfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
-| [azurerm_user_assigned_identity.svcfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
-| [random_password.truefoundry_db_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_container_registry.svcfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/container_registry) | resource |
+| [azurerm_federated_identity_credential.mlfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/federated_identity_credential) | resource |
+| [azurerm_federated_identity_credential.svcfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/federated_identity_credential) | resource |
+| [azurerm_key_vault.akv_svcfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/key_vault) | resource |
+| [azurerm_postgresql_flexible_server.postgresql_flexible](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/postgresql_flexible_server) | resource |
+| [azurerm_postgresql_flexible_server_configuration.postgres_flexible_configuration](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/postgresql_flexible_server_configuration) | resource |
+| [azurerm_postgresql_flexible_server_database.postgresql_flexible_database](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/postgresql_flexible_server_database) | resource |
+| [azurerm_postgresql_flexible_server_firewall_rule.postgres_flexible_firewall_rule](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/postgresql_flexible_server_firewall_rule) | resource |
+| [azurerm_role_assignment.acr_svcfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.mlfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.storage_svcfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/role_assignment) | resource |
+| [azurerm_storage_account.this](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/storage_account) | resource |
+| [azurerm_storage_container.truefoundry](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/storage_container) | resource |
+| [azurerm_subnet.postgresql_flexible_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/subnet) | resource |
+| [azurerm_user_assigned_identity.mlfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.svcfoundry](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/resources/user_assigned_identity) | resource |
+| [random_password.truefoundry_db_password](https://registry.terraform.io/providers/hashicorp/random/3.5.1/docs/resources/password) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.69.0/docs/data-sources/client_config) | data source |
 
 ## Inputs
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,18 +1,18 @@
 output "truefoundry_db_name" {
-  value = var.create_db == true ? var.database_name : "dummy"
+  value = var.create_db ? var.database_name : "dummy"
 }
 
 output "truefoundry_db_fqdn" {
-  value = var.create_db == true ? resource.azurerm_postgresql_flexible_server.postgresql_flexible[0].fqdn : "dummy"
+  value = var.create_db ? resource.azurerm_postgresql_flexible_server.postgresql_flexible[0].fqdn : "dummy"
 }
 
 output "truefoundry_db_password" {
-  value     = var.create_db == true ? random_password.truefoundry_db_password.result : "dummy"
+  value     = var.create_db ? random_password.truefoundry_db_password.result : "dummy"
   sensitive = true
 }
 
 output "truefoundry_db_username" {
-  value = var.create_db == true ? local.truefoundry_db_master_username : "dummy"
+  value = var.create_db ? local.truefoundry_db_master_username : "dummy"
 }
 
 output "truefoundry_db_port" {
@@ -20,11 +20,11 @@ output "truefoundry_db_port" {
 }
 
 output "truefoundry_db_subnet_id" {
-  value = var.create_db == true ? azurerm_subnet.postgresql_flexible_subnet[0].id : "dummy"
+  value = var.create_db ? azurerm_subnet.postgresql_flexible_subnet[0].id : "dummy"
 }
 
 output "truefoundry_storage_container_id" {
-  value = var.create_blob_storage == true ? azurerm_storage_container.truefoundry[0].id : "dummy"
+  value = var.create_blob_storage ? azurerm_storage_container.truefoundry[0].id : "dummy"
 }
 
 output "svcfoundry_identity_client_id" {

--- a/postgres.tf
+++ b/postgres.tf
@@ -5,8 +5,8 @@ resource "random_password" "truefoundry_db_password" {
 }
 
 resource "azurerm_subnet" "postgresql_flexible_subnet" {
-  count                = var.create_db ? var.truefoundry_db_subnet_shim ? 0 : 1 : 0
-  name                 = "${var.unique_name}-postgres-subnet"
+  count                = var.create_db ? 1 : 0
+  name                 = replace("${var.unique_name}-postgres", "-", "")
   resource_group_name  = var.resource_group_name
   virtual_network_name = var.truefoundry_db_vnet_name
   address_prefixes     = [var.truefoundry_db_subnet_cidr]
@@ -33,7 +33,7 @@ resource "azurerm_postgresql_flexible_server" "postgresql_flexible" {
   }
   administrator_login    = local.truefoundry_db_master_username
   administrator_password = random_password.truefoundry_db_password.result
-  delegated_subnet_id    = var.truefoundry_db_subnet_shim ? var.truefoundry_db_subnet_id : azurerm_subnet.postgresql_flexible_subnet[0].id
+  delegated_subnet_id    = azurerm_subnet.postgresql_flexible_subnet[0].id
   private_dns_zone_id    = var.truefoundry_db_private_dns_zone_id
   zone                   = "3"
   high_availability {

--- a/storage.tf
+++ b/storage.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "this" {
-  count                    = var.create_blob_storage == true ? 1 : 0
+  count                    = var.create_blob_storage ? 1 : 0
   name                     = replace(local.truefoundry_unique_name, "-", "")
   resource_group_name      = var.resource_group_name
   location                 = var.location
@@ -19,7 +19,7 @@ resource "azurerm_storage_account" "this" {
 }
 
 resource "azurerm_storage_container" "truefoundry" {
-  count                 = var.create_blob_storage == true ? 1 : 0
+  count                 = var.create_blob_storage ? 1 : 0
   name                  = local.truefoundry_unique_name
   storage_account_name  = azurerm_storage_account.this[0].name
   container_access_type = "blob"

--- a/variables.tf
+++ b/variables.tf
@@ -75,18 +75,6 @@ variable "truefoundry_db_allocated_storage" {
   description = "Storage for DB"
 }
 
-### Database subnet SHIM
-variable "truefoundry_db_subnet_shim" {
-  type        = bool
-  description = "DB subnet shim"
-}
-
-variable "truefoundry_db_subnet_id" {
-  type        = string
-  description = "Subnet ID where truefoundry database is hosted"
-  default     = ""
-}
-
 #### Network
 variable "truefoundry_db_vnet_name" {
   description = "Name of the virtual network"

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.69.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.5.1"
+    }
+  }
+}


### PR DESCRIPTION
1. DB subnet shim is removed as subnet is to be delegated to SQL service. This is not required at the end user.
2. Removed unnecessary `==true` conditions
3. Modified terraform linter to work only on PR to main branch