### PR TITLE
INFRA-902: append container name to truefoundry_blob_uri

### DIFF
--- a/.github/workflows/opentofu-test.yaml
+++ b/.github/workflows/opentofu-test.yaml
@@ -1,0 +1,13 @@
+name: OpenTofu tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  offline-plan-tests:
+    name: Offline plan-based tests
+    uses: truefoundry/github-workflows-public/.github/workflows/terraform-test.yml@main
+    with:
+      opentofu_version: "1.10.0"
+      test_directory: "tests"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Local .terraform directories
 **/.terraform/*
 
+# Terraform lock file
+.terraform.lock.hcl
+
 # .tfstate files
 *.tfstate
 *.tfstate.*

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ No modules.
 | <a name="output_mlfoundry_identity_client_id"></a> [mlfoundry\_identity\_client\_id](#output\_mlfoundry\_identity\_client\_id) | n/a |
 | <a name="output_svcfoundry_identity_client_id"></a> [svcfoundry\_identity\_client\_id](#output\_svcfoundry\_identity\_client\_id) | n/a |
 | <a name="output_truefoundry_blob_connection_string"></a> [truefoundry\_blob\_connection\_string](#output\_truefoundry\_blob\_connection\_string) | The primary connection string for the storage account |
-| <a name="output_truefoundry_blob_uri"></a> [truefoundry\_blob\_uri](#output\_truefoundry\_blob\_uri) | The primary blob endpoint URI for the storage account |
+| <a name="output_truefoundry_blob_uri"></a> [truefoundry\_blob\_uri](#output\_truefoundry\_blob\_uri) | The blob endpoint URI including the TrueFoundry container, e.g. https://<account>.blob.core.windows.net/<container> |
 | <a name="output_truefoundry_db_fqdn"></a> [truefoundry\_db\_fqdn](#output\_truefoundry\_db\_fqdn) | n/a |
 | <a name="output_truefoundry_db_name"></a> [truefoundry\_db\_name](#output\_truefoundry\_db\_name) | n/a |
 | <a name="output_truefoundry_db_password"></a> [truefoundry\_db\_password](#output\_truefoundry\_db\_password) | n/a |

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,8 +36,8 @@ output "mlfoundry_identity_client_id" {
 }
 
 output "truefoundry_blob_uri" {
-  description = "The primary blob endpoint URI for the storage account"
-  value       = var.create_blob_storage ? azurerm_storage_account.this[0].primary_blob_endpoint : ""
+  description = "The blob endpoint URI including the TrueFoundry container, e.g. https://<account>.blob.core.windows.net/<container>"
+  value       = var.create_blob_storage ? "${trimsuffix(azurerm_storage_account.this[0].primary_blob_endpoint, "/")}/${azurerm_storage_container.truefoundry[0].name}" : ""
 }
 
 output "truefoundry_blob_connection_string" {

--- a/tests/blob_uri.tftest.hcl
+++ b/tests/blob_uri.tftest.hcl
@@ -1,0 +1,75 @@
+# INFRA-902: truefoundry_blob_uri must include the container segment.
+#
+# primary_blob_endpoint is computed, so we mock the providers. The azurerm
+# provider validates several computed IDs as real Azure resource IDs at plan
+# time (role_assignment scope, federated_identity parent_id), so mock_resource
+# blocks supply valid-format IDs for those types. The container name is
+# config-derived (local.truefoundry_unique_name from cluster_name = "mycluster"),
+# so the expected URI is fully known. Two runs prove the trimsuffix guard handles
+# the endpoint both with and without a trailing slash.
+
+mock_provider "random" {}
+
+mock_provider "azurerm" {
+  mock_resource "azurerm_user_assigned_identity" {
+    defaults = {
+      id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/uai"
+      principal_id = "00000000-0000-0000-0000-000000000000"
+      client_id    = "00000000-0000-0000-0000-000000000000"
+    }
+  }
+
+  mock_resource "azurerm_storage_container" {
+    defaults = {
+      resource_manager_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Storage/storageAccounts/acct/blobServices/default/containers/mycluster"
+    }
+  }
+}
+
+variables {
+  resource_group_name                              = "rg-test"
+  cluster_name                                     = "mycluster"
+  location                                         = "eastus"
+  cluster_oidc_url                                 = "https://oidc.example/abc"
+  truefoundry_db_vnet_name                         = "vnet-test"
+  truefoundry_db_subnet_cidr                       = "10.0.20.0/28"
+  truefoundry_db_private_dns_zone_id               = "/subscriptions/x/zones/y"
+  truefoundry_db_allowed_ip_range_start_ip_address = "10.0.0.1"
+  truefoundry_db_allowed_ip_range_end_ip_address   = "10.0.0.254"
+  create_db                                        = false
+  create_acr                                       = false
+  create_kv                                        = false
+  create_blob_storage                              = true
+}
+
+run "endpoint_with_trailing_slash" {
+  command = plan
+
+  override_resource {
+    target = azurerm_storage_account.this
+    values = {
+      primary_blob_endpoint = "https://acct.blob.core.windows.net/"
+    }
+  }
+
+  assert {
+    condition     = output.truefoundry_blob_uri == "https://acct.blob.core.windows.net/mycluster"
+    error_message = "blob_uri must append the container with a single slash when endpoint has a trailing slash"
+  }
+}
+
+run "endpoint_without_trailing_slash" {
+  command = plan
+
+  override_resource {
+    target = azurerm_storage_account.this
+    values = {
+      primary_blob_endpoint = "https://acct.blob.core.windows.net"
+    }
+  }
+
+  assert {
+    condition     = output.truefoundry_blob_uri == "https://acct.blob.core.windows.net/mycluster"
+    error_message = "blob_uri must append the container with a single slash when endpoint has no trailing slash"
+  }
+}


### PR DESCRIPTION
Linear: [INFRA-902](https://linear.app/truefoundry/issue/INFRA-902/azure-control-plane-terraform-blob-storage-path-missing-container-name)

## Problem

Azure control-plane installs set `global.config.storageConfiguration.azureBlobUri` to only `https://<account>.blob.core.windows.net/` — the container segment is missing. TrueFoundry expects `https://<account>.blob.core.windows.net/<container>`. Observed in a WNS install (INFRA-902).

## Root cause

`truefoundry_blob_uri` returned the storage account's `primary_blob_endpoint` verbatim, which has no container. The container resource (`azurerm_storage_container.truefoundry`) already exists in the module but was never appended.

## Changes

- **`outputs.tf`** — append the container name to the blob URI. `trimsuffix(..., "/")` guards against a double slash if azurerm keeps the trailing `/`.
- **`tests/blob_uri.tftest.hcl`** — new native `tofu test` (`mock_provider`) asserting the URI resolves to `https://acct.blob.core.windows.net/mycluster` for endpoints both **with** and **without** a trailing slash. `tofu test` → 2 passed.
- **`.github/workflows/opentofu-test.yaml`** — run those tests on PRs via the shared `terraform-test.yml` workflow (OpenTofu 1.10.0), mirroring the sibling `terraform-aws-truefoundry-control-plane` repo.
- **`.gitignore`** — ignore `.terraform.lock.hcl`, matching the AWS control-plane repo.

## Follow-up

After merge + tag **v0.1.4**, bump the consumer pins (`0.1.3` → `0.1.4`):
- `servicefoundry-server` azure chart
- `tfy-infra-templates` azure/platform template

🤖 Generated with [Claude Code](https://claude.com/claude-code)
